### PR TITLE
Fix moneyphp v4 compatibility

### DIFF
--- a/src/Percent.php
+++ b/src/Percent.php
@@ -51,7 +51,7 @@ class Percent
      */
     public function applyTo(Money $amount): Money
     {
-        return $amount->multiply($this->value / 10000, Money::ROUND_HALF_DOWN);
+        return $amount->multiply(sprintf('%.14F', $this->value / 10000), Money::ROUND_HALF_DOWN);
     }
 
     /**


### PR DESCRIPTION
cf changelog money v4 php =>   (break] The methods multiply and divide do not accept floating points any more. Callers are required to convert a float to string (e.g. sprintf('%.14F', $float)) before calling these methods.