### PR TITLE
Standardize PHPStan config to use php-quality-config

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method AssoConnect\\PHPPercent\\Percent\:\:toRatio\(\) cannot have float as its return type \- floats are not allowed\.$#'
+			identifier: float.type
+			count: 1
+			path: src/Percent.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,8 @@
 parameters:
-    level: 8
     paths:
         - src/
         - tests/
+
 includes:
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-phpunit/rules.neon
-    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/assoconnect/php-quality-config/phpstan.extension.neon
+    - phpstan-baseline.neon


### PR DESCRIPTION
## Summary
- Replaced custom phpstan.neon.dist with standard php-quality-config include
- Added baseline for `Percent::toRatio()` float return type (inherent to API)
- Rector found no changes needed

## Test plan
- [x] Rector clean
- [x] PHPStan 0 errors (1 baselined)
- [x] PHPUnit passes (5 tests, 6 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)