### PR TITLE
Clean CI and upgrade analysis tools to latest on lowest dependency runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,29 +2,37 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.3', '8.4']
+        dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      
+
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-      
+
       - run: composer validate --strict
-      
-      - run: composer install --prefer-dist --no-progress --no-suggest
-      
+
+      - uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
+
+      - name: Upgrade analysis tools to latest
+        if: ${{ matrix.dependency-versions == 'lowest' }}
+        run: composer update phpstan/phpstan rector/rector phpunit/phpunit squizlabs/php_codesniffer --with-all-dependencies --no-interaction
+
       - run: vendor/bin/phpcs
         if: ${{ failure() ||  success() }}
 
@@ -36,12 +44,12 @@ jobs:
 
       - run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover ./clover.xml --log-junit ./phpunit.report.xml
         if: ${{ failure() ||  success() }}
-      
+
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747
       # $GITHUB_WORKSPACE contains a slash so @ is used as delimiter
       - run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' clover.xml
       - run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.report.xml
-      
+
       - uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /vendor/*
-.phpunit.result.cache
+.phpunit.cache
 .idea
 .php_cs.cache
 composer.lock

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-    <rule ref="PSR12"/>
+    <rule ref="./vendor/assoconnect/php-quality-config/phpcs.ruleset.xml"/>
 
     <file>src/</file>
     <file>tests/</file>


### PR DESCRIPTION
## Summary
- Replace `composer install` with `ramsey/composer-install@v2` for proper lowest/highest dependency support
- Upgrade `actions/checkout` from v2 to v4
- Fix CI trigger branch from `master` to `main`, add `fail-fast: false`
- Add `dependency-versions` matrix for lowest/highest testing
- Add step to upgrade phpstan, rector, phpunit and phpcs to latest when running with lowest dependencies
- Fix `phpcs.xml.dist` to use assoconnect ruleset instead of PSR12
- Fix `.gitignore` cache file name

🤖 Generated with [Claude Code](https://claude.com/claude-code)